### PR TITLE
Tweaks to the assessment metrics

### DIFF
--- a/quality.md
+++ b/quality.md
@@ -13,12 +13,12 @@ These hard figures help us to measure the effect of improvement work over time.
 | Measure | Definition (each calculated over the last 28 days) |
 |:---|:---|
 | Deployment frequency | Number of deployments
-| Lead time | Median time between an item being started to when it is done.
 
 ## Recommended:
 
 | Measure | Definition (each calculated over the last 28 days) |
 |:---|:---|
+| Lead time | Median time between an item being started to when it is done.
 | Change failure rate | Percentage of deployments which result in an incident.
 | Overall incident rate: P1 | Total number of priority 1 incidents which occurred.
 | Mean time to restore service: P1 | Mean time from priority 1 incident starting to when it is resolved.

--- a/quality.md
+++ b/quality.md
@@ -7,10 +7,18 @@ This framework aims to:
 
 # Metrics
 These hard figures help us to measure the effect of improvement work over time.
+
+## Essential:
+
 | Measure | Definition (each calculated over the last 28 days) |
 |:---|:---|
 | Deployment frequency | Number of deployments
 | Lead time | Median time between an item being started to when it is done.
+
+## Recommended:
+
+| Measure | Definition (each calculated over the last 28 days) |
+|:---|:---|
 | Change failure rate | Percentage of deployments which result in an incident.
 | Overall incident rate: P1 | Total number of priority 1 incidents which occurred.
 | Mean time to restore service: P1 | Mean time from priority 1 incident starting to when it is resolved.


### PR DESCRIPTION
Keen to keep the metrics burden as light as possible, as have historically taken the position that metrics should be chosen by the team to be the stuff most useful for the team - in this case we have a specific intent, and we need some data to track progress, which is fair enough - but let's keep to the absolute for our current intent.